### PR TITLE
make service-only default deploy, other bug fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,8 @@ test-service:
 # even if there is no server side code to deploy.
 #
 
-deploy: deploy-config deploy-client deploy-service
+# by default deploy only the service code
+deploy: deploy-service
 
 # deploy-all deploys client *and* server is depricated and should
 # be replaced by the deploy target.

--- a/install/bin/start_service
+++ b/install/bin/start_service
@@ -64,7 +64,7 @@ case "$1" in
         start_service
     ;;
     *)
-        start_tomcat
+#        start_tomcat
         start_service
     ;;
 esac

--- a/install/bin/stop_service
+++ b/install/bin/stop_service
@@ -57,7 +57,7 @@ case "$1" in
     ;;
     *)
         stop_service
-        stop_tomcat
+#        stop_tomcat
     ;;
 esac
 

--- a/src/search_service/search/__init__.py
+++ b/src/search_service/search/__init__.py
@@ -3,6 +3,7 @@ import os
 import os.path
 import logging
 import ConfigParser
+import time
 
 # local modules
 import exceptions

--- a/src/search_service/search/controllers.py
+++ b/src/search_service/search/controllers.py
@@ -261,7 +261,7 @@ def compute_solr_query(options, config):
             #facetDict[facetKey] = "(" + facetDict[facetKey] + ")"
 
             for k in xrange(len(facetOrder)):    
-                logger.info(facetDict[facetOrder[k])
+                logger.info(facetDict[facetOrder[k]])
                 facet_fields += "&facet.field={!ex=" + facetOrder[k] + "}" + facetOrder[k]
                 paramString += "&fq={!tag=" + facetOrder[k] + "}" + facetOrder[k] + ":" + "(" + facetDict[facetOrder[k]] + ")"
 

--- a/src/search_service/search/controllers.py
+++ b/src/search_service/search/controllers.py
@@ -7,7 +7,7 @@ import search
 
 from exceptions import InvalidSearchRequestError
 
-logger = search.getLogger()
+#logger = search.getLogger()
 
 def get_results(request, config):
     capture_metrics(request)
@@ -19,8 +19,8 @@ def get_results(request, config):
      # compute the solr url based on the user query
     computed_solr_url = compute_solr_query(validated, config)
     
-    logger.info(computed_solr_url)
-    logger.info("CHECK")
+#    logger.info(computed_solr_url)
+#    logger.info("CHECK")
 
     solr_results = dict()
     # call solr and retrieve result set
@@ -32,16 +32,16 @@ def get_results(request, config):
 
         solr_results = response.json()
     except Exception, e:
-        logger.error(computed_solr_url)
-        logger.exception(e)
+#        logger.error(computed_solr_url)
+#        logger.exception(e)
         raise
 
     try:
         # transform the json into the output format    
         results = transform_solr_json(solr_results, validated)
     except Exception, e:
-         logger.exception(e)
-         logger.info(solr_results)
+#         logger.exception(e)
+#         logger.info(solr_results)
          raise
 
     if validated.has_key("callback"):
@@ -210,7 +210,7 @@ def validate_inputs(query, config):
 def capture_metrics(request):
     headersString = ",".join([str(k) + " = " + str(request.headers[k]) for k in request.headers.keys()])
     
-    logger.info("METRICS -- " + " URL : " + request.url + " HEADERS : " + headersString)
+#    logger.info("METRICS -- " + " URL : " + request.url + " HEADERS : " + headersString)
 
 
 def compute_solr_query(options, config):
@@ -261,7 +261,7 @@ def compute_solr_query(options, config):
             #facetDict[facetKey] = "(" + facetDict[facetKey] + ")"
 
             for k in xrange(len(facetOrder)):    
-                logger.info(facetDict[facetOrder[k]])
+#                logger.info(facetDict[facetOrder[k]])
                 facet_fields += "&facet.field={!ex=" + facetOrder[k] + "}" + facetOrder[k]
                 paramString += "&fq={!tag=" + facetOrder[k] + "}" + facetOrder[k] + ":" + "(" + facetDict[facetOrder[k]] + ")"
 

--- a/src/search_service/search/controllers.py
+++ b/src/search_service/search/controllers.py
@@ -7,9 +7,11 @@ import search
 
 from exceptions import InvalidSearchRequestError
 
-#logger = search.getLogger()
 
 def get_results(request, config):
+
+    logger = search.getLogger()
+
     capture_metrics(request)
 
     # validate all of the required inputs
@@ -19,8 +21,8 @@ def get_results(request, config):
      # compute the solr url based on the user query
     computed_solr_url = compute_solr_query(validated, config)
     
-#    logger.info(computed_solr_url)
-#    logger.info("CHECK")
+    logger.info(computed_solr_url)
+    logger.info("CHECK")
 
     solr_results = dict()
     # call solr and retrieve result set
@@ -32,16 +34,16 @@ def get_results(request, config):
 
         solr_results = response.json()
     except Exception, e:
-#        logger.error(computed_solr_url)
-#        logger.exception(e)
+        logger.error(computed_solr_url)
+        logger.exception(e)
         raise
 
     try:
         # transform the json into the output format    
         results = transform_solr_json(solr_results, validated)
     except Exception, e:
-#         logger.exception(e)
-#         logger.info(solr_results)
+         logger.exception(e)
+         logger.info(solr_results)
          raise
 
     if validated.has_key("callback"):
@@ -54,7 +56,10 @@ def get_results(request, config):
 
 
 def transform_solr_json(results, params):
-    #logger.info(results)
+
+    logger = search.getLogger()
+
+    logger.info(results)
 
     transform = dict()
     transform["items"] = list()
@@ -114,6 +119,9 @@ def transform_solr_json(results, params):
 
 
 def validate_inputs(query, config):
+
+    logger = search.getLogger()
+
     validatedParams = dict()
 
     # check for a jsonp callback
@@ -208,12 +216,18 @@ def validate_inputs(query, config):
             
 
 def capture_metrics(request):
+
+    logger = search.getLogger()
+
     headersString = ",".join([str(k) + " = " + str(request.headers[k]) for k in request.headers.keys()])
     
-#    logger.info("METRICS -- " + " URL : " + request.url + " HEADERS : " + headersString)
+    logger.info("METRICS -- " + " URL : " + request.url + " HEADERS : " + headersString)
 
 
 def compute_solr_query(options, config):
+
+    logger = search.getLogger()
+
     mapping = "search"
     paramString = ""
     facet_fields = ""
@@ -261,7 +275,7 @@ def compute_solr_query(options, config):
             #facetDict[facetKey] = "(" + facetDict[facetKey] + ")"
 
             for k in xrange(len(facetOrder)):    
-#                logger.info(facetDict[facetOrder[k]])
+                logger.info(facetDict[facetOrder[k]])
                 facet_fields += "&facet.field={!ex=" + facetOrder[k] + "}" + facetOrder[k]
                 paramString += "&fq={!tag=" + facetOrder[k] + "}" + facetOrder[k] + ":" + "(" + facetDict[facetOrder[k]] + ")"
 


### PR DESCRIPTION
This PR mostly changes the deployment and start/stop scripts so that the service is the only thing deployed by default.  If you want to deploy solr you need to specify the appropriate make targets, and if you want to start or stop Tomcat you need to specify that on the {start,stop}_service command line explicitly.

There are some other bug fixes as well to make the service deployable:

**init**.py needs to import the time module
controllers.py has a circular dependency on the search module (which calls **init**.py, which imports controllers), which causes problems defining the logger object.  I've moved the logger=search.getLogger() calls inside each function to work around the circular dependency.  That may not be the absolutely correct way to do it, but it works.

controllers.py also had a missing ] on line 264.
